### PR TITLE
Add resilience to SQLite reading of the field Account.SyncGuid field

### DIFF
--- a/Source/WPF/MyMoney/Database/SqlDatabase.cs
+++ b/Source/WPF/MyMoney/Database/SqlDatabase.cs
@@ -1078,9 +1078,16 @@ namespace Walkabout.Data
                     a.LastBalance = reader.SafeGetDateTime(8);
                 }
 
-                if (!reader.IsDBNull(9))
+                if (!reader.IsDBNull(9) && reader.GetString(9).Trim().Length > 0)
                 {
-                    a.SyncGuid = new SqlGuid(reader.GetGuid(9));
+                    try
+                    {
+                        a.SyncGuid = new SqlGuid(reader.GetGuid(9));
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.WriteLine("### invalid GUID Error: {0}", ex.Message);
+                    }
                 }
 
                 if (!reader.IsDBNull(10))


### PR DESCRIPTION
I hit this problem when working between the flutter version and the windows version. This fix adds just a bit of tolerance to the field being either null or empty "".   I suggest that we could do the same for most fields