### PR TITLE
remove bad safeguard, Checking for reader.GetString(9) on a GUID field

### DIFF
--- a/Source/WPF/MyMoney/Database/SqlDatabase.cs
+++ b/Source/WPF/MyMoney/Database/SqlDatabase.cs
@@ -1078,7 +1078,7 @@ namespace Walkabout.Data
                     a.LastBalance = reader.SafeGetDateTime(8);
                 }
 
-                if (!reader.IsDBNull(9) && reader.GetString(9).Trim().Length > 0)
+                if (!reader.IsDBNull(9))
                 {
                     try
                     {


### PR DESCRIPTION
This was causing a runtime crash on my Sqlite DB loading, GUID field throws an exception when looked at using GetString().